### PR TITLE
turn off (all) email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,5 @@ install:
 script:
   - make test
 
+notifications:
+  email: false


### PR DESCRIPTION
i think this also turns off the notifications for the committer.

don't think it's possible to keep those but not notify the repo owner (which is techteam@)
