### PR TITLE
stash the temp db list during connection tests

### DIFF
--- a/kaiso/connection.py
+++ b/kaiso/connection.py
@@ -25,6 +25,7 @@ temp_neo4j = namedtuple('temp_neo4j', ['http_url', 'process'])
 _temporary_databases = {}
 
 TIMEOUT = 30  # seconds
+DEFAULT_TEMP_PORT = 7475
 
 
 def get_neo4j_info():
@@ -84,7 +85,7 @@ def temp_neo4j_instance(uri):
     """
     # split the uri
     split_uri = urlparse.urlparse(uri)
-    port = split_uri.port or 7475
+    port = split_uri.port or DEFAULT_TEMP_PORT
     bind_iface = split_uri.hostname or "localhost"
 
     # return http uri if this temporary database already exists

--- a/test/test_connections.py
+++ b/test/test_connections.py
@@ -53,11 +53,13 @@ class TestTempConnectionProcesses():
         """ Verify temporary connection with default options.
         """
         with patch('py2neo.neo4j.GraphDatabaseService', lambda uri: uri):
-            conn = get_connection('temp://')
+            # make sure we don't clash with the default temp port
+            with patch('kaiso.connection.DEFAULT_TEMP_PORT', 7776):
+                conn = get_connection('temp://')
 
-        assert conn == "http://localhost:7475/db/data/"
+        assert conn == "http://localhost:7776/db/data/"
         self.write_config.assert_called_once_with(
-            ANY, 7475, ANY, 'localhost'
+            ANY, 7776, ANY, 'localhost'
         )
 
     def test_temp_connection_custom_port(self):


### PR DESCRIPTION
that way we don't need to rely on those running first
